### PR TITLE
Changeset alert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+resources/public/out/
+resources/public/out_dev/
+resources/medusa.sqlite

--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,10 @@
                  [org.clojure/core.match  "0.2.1"]
                  [clj-time "0.8.0"]
                  [com.cemerick/friend "0.2.1"]
-                 [amazonica "0.2.24"]
+                 [amazonica "0.2.24" :exclusions [joda-time]]
+                 [clj-http-lite "0.2.1"]
+                 [clj-tagsoup "0.3.0" :exclusions [org.clojure/clojure]]
+                 [org.clojure/tools.logging "0.3.1"]
 
                  [weasel "0.4.0-SNAPSHOT"]
                  [org.clojure/clojurescript "0.0-3123"]

--- a/src/clj/medusa/alert.clj
+++ b/src/clj/medusa/alert.clj
@@ -4,10 +4,17 @@
             [clojure.string :as string]
             [clj.medusa.config :as config]
             [clj.medusa.db :as db]
-            [clj.medusa.config :as config]))
+            [clj.medusa.config :as config]
+            [clj.medusa.changesets :as changesets]
+            [clojure.tools.logging :as log]))
 
 (defn send-email [subject body destinations]
-  (when-not (:dry-run @config/state)
+  (if (:dry-run @config/state) ; Dry run, don't actually send out emails
+    (do (println "================ EMAIL NOTIFICATION ================")
+        (println "EMAIL TO " destinations ":")
+        (println "SUBJECT: " subject)
+        (println "BODY: " subject)
+        (println "===================================================="))
     (ses/send-email :destination {:to-addresses destinations}
                     :source "telemetry-alerts@mozilla.com"
                     :message {:subject subject
@@ -20,8 +27,17 @@
          detector_id :detector_id
          metric_id :id} (db/get-metric metric_id)
         {detector_name :name} (db/get-detector detector_id)
-        subscribers (db/get-subscribers-for-metric metric_id)]
-    (send-email (str "Alert for " metric_name " (" detector_name ") on the " date)
-                (str "http://" hostname "/index.html#/detectors/" detector_id "/"
-                     "metrics/" metric_id "/alerts/?from=" date "&to=" date)
-                (concat subscribers foreign_subscribers ["dev-telemetry-alerts@lists.mozilla.org"])))) 
+        subscribers (db/get-subscribers-for-metric metric_id)
+        alert-url (str "http://" hostname "/index.html#/detectors/" detector_id "/metrics/" metric_id "/alerts/?from=" date "&to=" date)]
+    (try
+      (let [buildid (changesets/find-date-buildid date "mozilla-central") ; get the buildid for the given date
+            changeset-url (changesets/find-build-changeset buildid "mozilla-central")]
+        (log/info "Changeset URL" changeset-url)
+        (send-email (str "Alert for " metric_name " (" detector_name ") on " date)
+                    (str "Alert details: " alert-url " (Changeset for " buildid ": " changeset-url ")")
+                    (concat subscribers foreign_subscribers ["dev-telemetry-alerts@lists.mozilla.org"])))
+      (catch Exception e ; could not find revisions for the given build date
+        (log/error e "Retrieving changeset failed")
+        (send-email (str "Alert for " metric_name " (" detector_name ") on " date)
+                    (str "Alert details: " alert-url)
+                    (concat subscribers foreign_subscribers ["dev-telemetry-alerts@lists.mozilla.org"]))))))

--- a/src/clj/medusa/changesets.clj
+++ b/src/clj/medusa/changesets.clj
@@ -2,23 +2,44 @@
   (:require [clj-http.lite.client :as client]
             [pl.danieljanus.tagsoup :as tagsoup]))
 
-(defn split-buildid [buildid]
+;; This library finds changesets given build dates (dates of the form YYYY-MM-DD)
+;; or build IDs (exact build timestamps of the form YYYYMMDDhhmmss).
+;;
+;; Example: obtaining a link to the changesets for build date 2015-05-03:
+;;
+;;     (println (find-build-changeset (find-date-buildid "2015-05-03" "mozilla-central") "mozilla-central"))
+;;
+;; Example: obtaining a link to changesets for buildid 20150503030209
+;;
+;;     (println (find-build-changeset "20150503030209" "mozilla-central"))
+
+(declare elements-by-tag-name)
+
+(defn- split-buildid
+  "Splits a buildid `buildid` into a dictionary with the date/time components as entries."
+  [buildid]
   {:y (Integer/parseInt (subs buildid 0 4)) :m (Integer/parseInt (subs buildid 4 6)) :d (Integer/parseInt (subs buildid 6 8))
    :hour (Integer/parseInt (subs buildid 8 10)) :min (Integer/parseInt (subs buildid 10 12)) :sec (Integer/parseInt (subs buildid 12 14))})
 
-(declare elements-by-tag-name)
-(defn list-elements-by-tag-name [children tag-name]
+(defn- list-elements-by-tag-name
+  "Obtains a list of all tags with tag name `tag-name` in `children`, a list of DOM elements in the form outputted by Tagsoup."
+  [children tag-name]
   (cond (empty? children) '()
         (vector? (first children)) (concat (elements-by-tag-name (first children) tag-name)
                                            (list-elements-by-tag-name (rest children) tag-name))
         :else '()))
-(defn elements-by-tag-name [tag tag-name]
+
+(defn- elements-by-tag-name
+  "Obtains a list of all tags with tag name `tag-name` in `tag`, a DOM in the form outputted by Tagsoup."
+  [tag tag-name]
   {:pre [(vector? tag) (keyword? tag-name)]}
   (if (= (first tag) :a)
     (cons tag (list-elements-by-tag-name (rest (rest tag)) tag-name))
     (list-elements-by-tag-name (rest (rest tag)) tag-name)))
 
-(defn find-build-dir-revision [build-dir-url]
+(defn- find-build-dir-revision
+  "Finds the hg revision associated with the build dir URL `build-dir-url`."
+  [build-dir-url]
   (let [response (tagsoup/parse build-dir-url)
         links (elements-by-tag-name response :a)
         text-file-links (filter #(re-find #"^firefox.*win32\.txt$" (get % 2)) links)]
@@ -28,13 +49,17 @@
           revision (re-find #"https:\/\/hg\.mozilla.*([0-9a-f]{12})$" revision-file)]
       (second revision))))
 
-(defn find-build-revision [buildid channel]
+(defn- find-build-revision
+  "Finds the hg revision of associated with the buildid `buildid` on channel `channel`."
+  [buildid channel]
   (let [p (split-buildid buildid)
         build-dir-url (format "http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/%02d/%02d/%02d-%02d-%02d-%02d-%02d-%02d-%s/"
                     (:y p) (:m p) (:y p) (:m p) (:d p) (:hour p) (:min p) (:sec p) channel)]
     (find-build-dir-revision build-dir-url)))
 
-(defn find-preceding-build-revision [buildid channel]
+(defn- find-preceding-build-revision
+  "Find the first build made before buildid `buildid` on channel `channel`, and get its associated revision."
+  [buildid channel]
   (let [p (split-buildid buildid)
 
         ;; Obtain a list of links to build directories in the desired channel
@@ -62,13 +87,17 @@
               build-dir-url (str build-dirs-url (:href (second target-link)))]
           (find-build-dir-revision build-dir-url)))))
 
-(defn find-build-changeset [buildid channel]
+(defn find-build-changeset
+  "Finds the changesets corresponding to the build with buildid `buildid`, which is a URL for a page with a list of all new changesets that went into that build."
+  [buildid channel]
   (let [from-revision (find-preceding-build-revision buildid channel)
         to-revision (find-build-revision buildid channel)]
     (format "https://hg.mozilla.org/%s/pushloghtml?fromchange=%s&tochange=%s"
             channel from-revision to-revision)))
 
-(defn find-date-buildid [date channel] ; date should be of the form yyyy-MM-dd
+(defn find-date-buildid
+  "Determines the buildid (a date-time of the form YYYYMMDDhhmmss) corresponding to a given build date `date` (a date of the form YYYY-MM-DD) on the channel string `channel`, generally mozilla-central."
+  [date channel]
   (let [[_ year month day] (re-find #"^(\d{4})-(\d{2})-(\d{2})$" date)
         build-dirs-suffix (format "-%s/" channel)
         build-dirs-url (format "https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/%s/%s/" year month)
@@ -78,5 +107,3 @@
         target-link (first (filter #(.startsWith (get % 2) date) build-dirs-links))
         [_ hour minute second] (re-find #"^\d{4}-\d{2}-\d{2}-(\d{2})-(\d{2})-(\d{2})" (get target-link 2))]
     (str year month day hour minute second)))
-
-;(println (find-build-changeset (find-date-buildid "2015-05-03" "mozilla-central") "mozilla-central"))

--- a/src/clj/medusa/changesets.clj
+++ b/src/clj/medusa/changesets.clj
@@ -1,0 +1,82 @@
+(ns clj.medusa.changesets
+  (:require [clj-http.lite.client :as client]
+            [pl.danieljanus.tagsoup :as tagsoup]))
+
+(defn split-buildid [buildid]
+  {:y (Integer/parseInt (subs buildid 0 4)) :m (Integer/parseInt (subs buildid 4 6)) :d (Integer/parseInt (subs buildid 6 8))
+   :hour (Integer/parseInt (subs buildid 8 10)) :min (Integer/parseInt (subs buildid 10 12)) :sec (Integer/parseInt (subs buildid 12 14))})
+
+(declare elements-by-tag-name)
+(defn list-elements-by-tag-name [children tag-name]
+  (cond (empty? children) '()
+        (vector? (first children)) (concat (elements-by-tag-name (first children) tag-name)
+                                           (list-elements-by-tag-name (rest children) tag-name))
+        :else '()))
+(defn elements-by-tag-name [tag tag-name]
+  {:pre [(vector? tag) (keyword? tag-name)]}
+  (if (= (first tag) :a)
+    (cons tag (list-elements-by-tag-name (rest (rest tag)) tag-name))
+    (list-elements-by-tag-name (rest (rest tag)) tag-name)))
+
+(defn find-build-dir-revision [build-dir-url]
+  (let [response (tagsoup/parse build-dir-url)
+        links (elements-by-tag-name response :a)
+        text-file-links (filter #(re-find #"^firefox.*win32\.txt$" (get % 2)) links)]
+    (assert (= (count text-file-links) 1) "Could not find revision ID text file")
+    (let [revision-file-url (str build-dir-url (:href (second (first text-file-links))))
+          revision-file (:body (client/get revision-file-url))
+          revision (re-find #"https:\/\/hg\.mozilla.*([0-9a-f]{12})$" revision-file)]
+      (second revision))))
+
+(defn find-build-revision [buildid channel]
+  (let [p (split-buildid buildid)
+        build-dir-url (format "http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/%02d/%02d/%02d-%02d-%02d-%02d-%02d-%02d-%s/"
+                    (:y p) (:m p) (:y p) (:m p) (:d p) (:hour p) (:min p) (:sec p) channel)]
+    (find-build-dir-revision build-dir-url)))
+
+(defn find-preceding-build-revision [buildid channel]
+  (let [p (split-buildid buildid)
+
+        ;; Obtain a list of links to build directories in the desired channel
+        build-dirs-url (format "https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/%02d/%02d/" (:y p) (:m p))
+        target (format "%02d-%02d-%02d-%02d-%02d-%02d-%s/" (:y p) (:m p) (:d p) (:hour p) (:min p) (:sec p) channel)
+        response (tagsoup/parse build-dirs-url)
+        links (elements-by-tag-name response :a)
+        build-dirs-suffix (format "-%s/" channel)
+        build-dirs-links (filter #(.endsWith (get % 2) build-dirs-suffix) links)
+
+        ;; Find the index of the link before the link having the specified buildid
+        target-link-index (dec (first (keep-indexed #(when (= (clojure.string/trim (get %2 2)) target) %1) build-dirs-links)))]
+    (if (= target-link-index -1) ; check if we have the directory of previous build in the same month's folder
+        (let [year (if (= (:m p) 0) (dec (:y p)) (:y p)) ; the build is the first one in that month, use the last build of the previous month's folder
+              month (if (= (:m p) 0) 12 (dec (:m p)))
+
+              ;; Obtain the last link to build directories in the desired channel in the previous month's folder, which is the build dir of the last build in the previous month
+              prev-build-dirs-url (format "https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/%02d/%02d/" year month)
+              response (tagsoup/parse prev-build-dirs-url)
+              links (elements-by-tag-name response :a)
+              target-link (last (filter #(.endsWith (get % 2) build-dirs-suffix) links))
+              build-dir-url (str prev-build-dirs-url (:href (second target-link)))]
+          (find-build-dir-revision build-dir-url))
+        (let [target-link (nth build-dirs-links target-link-index) ; get the build directory and the revision from the link
+              build-dir-url (str build-dirs-url (:href (second target-link)))]
+          (find-build-dir-revision build-dir-url)))))
+
+(defn find-build-changeset [buildid channel]
+  (let [from-revision (find-preceding-build-revision buildid channel)
+        to-revision (find-build-revision buildid channel)]
+    (format "https://hg.mozilla.org/%s/pushloghtml?fromchange=%s&tochange=%s"
+            channel from-revision to-revision)))
+
+(defn find-date-buildid [date channel] ; date should be of the form yyyy-MM-dd
+  (let [[_ year month day] (re-find #"^(\d{4})-(\d{2})-(\d{2})$" date)
+        build-dirs-suffix (format "-%s/" channel)
+        build-dirs-url (format "https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/%s/%s/" year month)
+        response (tagsoup/parse build-dirs-url)
+        links (elements-by-tag-name response :a)
+        build-dirs-links (filter #(.endsWith (get % 2) build-dirs-suffix) links)
+        target-link (first (filter #(.startsWith (get % 2) date) build-dirs-links))
+        [_ hour minute second] (re-find #"^\d{4}-\d{2}-\d{2}-(\d{2})-(\d{2})-(\d{2})" (get target-link 2))]
+    (str year month day hour minute second)))
+
+;(println (find-build-changeset (find-date-buildid "2015-05-03" "mozilla-central") "mozilla-central"))

--- a/src/clj/medusa/db.clj
+++ b/src/clj/medusa/db.clj
@@ -117,6 +117,9 @@
                            :metric_id 2}))
     (insert alert (values {:date "2014-07-05",
                            :description "{}",
+                           :metric_id 2}))
+    (insert alert (values {:date "2014-07-06",
+                           :description "{\"x_label\": \"Update: number of sequential update elevation request cancelations greater than 0 (timer initiated)\", \"type\": \"graph\", \"link\": \"http://telemetry.mozilla.org/#filter=nightly/nn/UPDATE_PREF_UPDATE_CANCELATIONS_NOTIFY\", \"reference_series\": [0.0, 0.35934799909591675, 0.153371199965477], \"y_label\": \"Normalized Frequency Count\", \"series_label\": \"2015-05-25\", \"series\": [0.0, 0.3749297261238098, 0.1498032659292221], \"buckets\": [0, 1, 2], \"title\": \"UPDATE_PREF_UPDATE_CANCELATIONS_NOTIFY\", \"reference_series_label\": \"Previous build-id\"}",
                            :metric_id 2})))
   (when (empty? (select user_metric))
     (insert user_metric (values {:user_id 1


### PR DESCRIPTION
* Alert emails now link to the pushlog for the alert's build date.
* For example, an alert for a build made on 2015-05-03 will have a link to https://hg.mozilla.org/mozilla-central/pushloghtml?fromchange=1e8d30cb367e&tochange=dc5f85980a82
* The changeset finder is ported over from the ES6 library https://github.com/bsmedberg/firefox-regression-range-finder.
* Also add a `.gitignore` and error logging for email sending.