### PR TITLE
Changeset alert

### DIFF
--- a/src/clj/medusa/alert.clj
+++ b/src/clj/medusa/alert.clj
@@ -34,7 +34,7 @@
             changeset-url (changesets/find-build-changeset buildid "mozilla-central")]
         (log/info "Changeset URL" changeset-url)
         (send-email (str "Alert for " metric_name " (" detector_name ") on " date)
-                    (str "Alert details: " alert-url " (Changeset for " buildid ": " changeset-url ")")
+                    (str "Alert details: " alert-url "\n\n" "Changeset for " buildid ": " changeset-url)
                     (concat subscribers foreign_subscribers ["dev-telemetry-alerts@lists.mozilla.org"])))
       (catch Exception e ; could not find revisions for the given build date
         (log/error e "Retrieving changeset failed")

--- a/src/clj/medusa/changesets.clj
+++ b/src/clj/medusa/changesets.clj
@@ -53,7 +53,7 @@
   "Finds the hg revision of associated with the buildid `buildid` on channel `channel`."
   [buildid channel]
   (let [p (split-buildid buildid)
-        build-dir-url (format "http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/%02d/%02d/%02d-%02d-%02d-%02d-%02d-%02d-%s/"
+        build-dir-url (format "https://archive.mozilla.org/pub/mozilla.org/firefox/nightly/%02d/%02d/%02d-%02d-%02d-%02d-%02d-%02d-%s/"
                     (:y p) (:m p) (:y p) (:m p) (:d p) (:hour p) (:min p) (:sec p) channel)]
     (find-build-dir-revision build-dir-url)))
 
@@ -63,7 +63,7 @@
   (let [p (split-buildid buildid)
 
         ;; Obtain a list of links to build directories in the desired channel
-        build-dirs-url (format "https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/%02d/%02d/" (:y p) (:m p))
+        build-dirs-url (format "https://archive.mozilla.org/pub/mozilla.org/firefox/nightly/%02d/%02d/" (:y p) (:m p))
         target (format "%02d-%02d-%02d-%02d-%02d-%02d-%s/" (:y p) (:m p) (:d p) (:hour p) (:min p) (:sec p) channel)
         response (tagsoup/parse build-dirs-url)
         links (elements-by-tag-name response :a)
@@ -77,7 +77,7 @@
               month (if (= (:m p) 0) 12 (dec (:m p)))
 
               ;; Obtain the last link to build directories in the desired channel in the previous month's folder, which is the build dir of the last build in the previous month
-              prev-build-dirs-url (format "https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/%02d/%02d/" year month)
+              prev-build-dirs-url (format "https://archive.mozilla.org/pub/mozilla.org/firefox/nightly/%02d/%02d/" year month)
               response (tagsoup/parse prev-build-dirs-url)
               links (elements-by-tag-name response :a)
               target-link (last (filter #(.endsWith (get % 2) build-dirs-suffix) links))
@@ -100,7 +100,7 @@
   [date channel]
   (let [[_ year month day] (re-find #"^(\d{4})-(\d{2})-(\d{2})$" date)
         build-dirs-suffix (format "-%s/" channel)
-        build-dirs-url (format "https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/%s/%s/" year month)
+        build-dirs-url (format "https://archive.mozilla.org/pub/mozilla.org/firefox/nightly/%s/%s/" year month)
         response (tagsoup/parse build-dirs-url)
         links (elements-by-tag-name response :a)
         build-dirs-links (filter #(.endsWith (get % 2) build-dirs-suffix) links)


### PR DESCRIPTION
`ftp.mozilla.org` is being replaced by `archive.mozilla.org`. Medusa should also use this in order to continue showing changesets after the cutoff date.

    As promised, the FTP Migration team is following up from the 7/20 Monday Project Meeting where Sean Rich talked about a project that is underway to make our Product Delivery System better.


    As a part of this project, we are migrating content out of our data centers to AWS. In addition to storage locations changing, namespaces will change and the FTP protocol for this system will be deprecated. If, after reading this email, you have any further questions, please email the team at ftpmigration@mozilla.com

    tl;dr

    Action:  The ftp protocol on ftp.mozilla.org is being turned off.

    Timing:  Wednesday, 8/5/15.

    Impacts:  

        After 8/5/15, ftp protocol support for ftp.mozilla.org will be completely disabled and downloads can only be accessed through http/https.  

        Users will no longer be able to just enter “ftp.mozilla.org” into their browser, because this action defaults to the ftp protocol.  Going forward, users should start using archive.mozilla.org.  The old name will still work but needs to be entered in your browser as https://ftp.mozilla.org.


    Action:  The contents of ftp.mozilla.org are being migrated from the NetApp in PHX1 to AWS/S3 managed by Cloud Services.

    Timing:  Migrating ftp.mozilla.org contents will start in late August and conclude by end of October.  Impacted teams will be notified of their migration date.

    Impacts:

        Those teams that currently manually upload to these locations have been contacted and will be provided with S3 API keys.  They will be notified prior to their migration date and given a chance to validate their upload functionality post-migration.
        All existing download links will continue to work as they do now with no impact.

    - the FTP Migration team