### PR TITLE
Catch all errors in changeset linking library

### DIFF
--- a/src/clj/medusa/alert.clj
+++ b/src/clj/medusa/alert.clj
@@ -36,7 +36,7 @@
         (send-email (str "Alert for " metric_name " (" detector_name ") on " date)
                     (str "Alert details: " alert-url "\n\n" "Changeset for " buildid ": " changeset-url)
                     (concat subscribers foreign_subscribers ["dev-telemetry-alerts@lists.mozilla.org"])))
-      (catch Exception e ; could not find revisions for the given build date
+      (catch Throwable e ; could not find revisions for the given build date
         (log/error e "Retrieving changeset failed")
         (send-email (str "Alert for " metric_name " (" detector_name ") on " date)
                     (str "Alert details: " alert-url)


### PR DESCRIPTION
Originally we were catching Exceptions, but today there was a buildID that threw an AssertionError instead (the revision text file was missing on the FTP server). This caused Medusa to crash since AssertionErrors are not Exceptions, so we couldn't catch it.