### PR TITLE
Tweak changeset retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 resources/public/out/
 resources/public/out_dev/
 resources/medusa.sqlite
+.vagrant/
+target/
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "dev" do |dev|
     dev.ssh.insert_key = false
-    dev.vm.box = "ubuntu/vivid64"
+    dev.vm.box = "ubuntu/wily64"
     dev.vm.network :forwarded_port, host: 8080, guest: 8080
     dev.vm.provision "ansible" do |ansible|
       ansible.host_key_checking = false

--- a/src/clj/medusa/alert.clj
+++ b/src/clj/medusa/alert.clj
@@ -38,7 +38,7 @@
                     (str "Alert details: " alert-url "\n\n" "Changeset for " buildid ": " changeset-url)
                     (concat subscribers foreign_subscribers ["dev-telemetry-alerts@lists.mozilla.org"])))
       (catch Throwable e ; could not find revisions for the given build date
-        (log/error e "Retrieving changeset failed")
+        (log/info e "Retrieving changeset failed")
         (send-email (str "Alert for " metric_name " (" detector_name ") on " date)
                     (str "Alert details: " alert-url)
                     (concat subscribers foreign_subscribers ["dev-telemetry-alerts@lists.mozilla.org"]))))))

--- a/src/clj/medusa/changesets.clj
+++ b/src/clj/medusa/changesets.clj
@@ -81,7 +81,7 @@
               response (tagsoup/parse prev-build-dirs-url)
               links (elements-by-tag-name response :a)
               target-link (last (filter #(.endsWith (get % 2) build-dirs-suffix) links))
-              build-dir-url (str prev-build-dirs-url (:href (second target-link)))]
+              build-dir-url (str "https://archive.mozilla.org" (:href (second target-link)))]
           (find-build-dir-revision build-dir-url))
         (let [target-link (nth build-dirs-links target-link-index) ; get the build directory and the revision from the link
               build-dir-url (str "https://archive.mozilla.org" (:href (second target-link)))]


### PR DESCRIPTION
* Changeset URLs would often be broken on the first of the month.
* The vivid64 image is no longer available, since it's not LTS.
* Update .gitignore.