### PR TITLE
Add a smoke test for find-date-buildid.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ resources/public/out_dev/
 resources/medusa.sqlite
 .vagrant/
 target/
-
+/.lein-failures

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ To provision resources and deploy medusa on AWS, first edit `ansible/provision.y
 ansible-playbook ansible/provision.yml -i ansible/inventory
 ```
 
+To run tests, run `lein test`.
+
 ## Usage
 
 To launch the server simply yield `lein run`. Note that you must have a recent version of leiningen installed (> 2); some distributions ship with earlier versions.

--- a/test/medusa/changesets_test.clj
+++ b/test/medusa/changesets_test.clj
@@ -1,0 +1,7 @@
+(ns medusa.changesets-test
+  (:require [clojure.test :refer :all]
+            [clj.medusa.changesets :refer [find-date-buildid]]))
+
+(deftest find-date-buildid-smoke
+  (testing "Unremarkable invocation of find-date-buildid"
+    (is (= (find-date-buildid "2017-09-18" "mozilla-central") "20170918100059"))))

--- a/test/medusa/core_test.clj
+++ b/test/medusa/core_test.clj
@@ -1,7 +1,0 @@
-(ns medusa.core-test
-  (:require [clojure.test :refer :all]
-            [medusa.core :refer :all]))
-
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))


### PR DESCRIPTION
This should help us revise it to return multiple buildids without having to test in production.

Remove non-working example core_test.clj, which crashed because it required "medusa.core" rather than "clj.medusa.core".

I envision us merging this to master, then merging out from master to PR #20, then twiddling till it works, under the glorious supervision of a single piddling test. (I expect we'll want to refactor find-date-buildid to have dependencies injected, such that it doesn't actually have to go out and hit the network, but I didn't want to complicate this PR with that. Naive tests are better than no tests.)