### PR TITLE
Multiple buildids per day

### DIFF
--- a/src/clj/medusa/alert.clj
+++ b/src/clj/medusa/alert.clj
@@ -19,6 +19,11 @@
                     :message {:subject subject
                               :body {:text body}})))
 
+(defn- build-range
+  "Returns 'abc123' if there's only 1 build. Otherwise, return 'abc123...def456'."
+  [earliest-build latest-build]
+  (if (= earliest-build latest-build) earliest-build (str earliest-build "..." latest-build)))
+
 (defn notify-subscribers [{:keys [metric_id date emails]}]
   (let [{:keys [hostname]} @config/state
         foreign_subscribers (when (seq emails) (string/split emails #","))
@@ -35,7 +40,7 @@
         (send-email (str "Alert for " metric_name " (" detector_name ") on " date)
                     (str "Alert details: " alert-url
                          "\n\n"
-                         "Changeset for " earliest-build "..." latest-build ": " changeset-url)
+                         "Changeset for " (build-range earliest-build latest-build) ": " changeset-url)
                     (concat subscribers foreign_subscribers ["dev-telemetry-alerts@lists.mozilla.org"])))
       (catch Throwable e ; could not find revisions for the given build date
         (log/info e "Retrieving changeset failed")

--- a/test/medusa/alert_test.clj
+++ b/test/medusa/alert_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [clj.medusa.alert]))
 
-(deftest build-range
+(deftest test-build-range
   (testing "single build in a day"
     (is (= (#'clj.medusa.alert/build-range "20170102030405" "20170102030405") "20170102030405")))
   (testing "multiple builds in a day"

--- a/test/medusa/alert_test.clj
+++ b/test/medusa/alert_test.clj
@@ -1,0 +1,9 @@
+(ns medusa.alert-test
+  (:require [clojure.test :refer :all]
+            [clj.medusa.alert]))
+
+(deftest build-range
+  (testing "single build in a day"
+    (is (= (#'clj.medusa.alert/build-range "20170102030405" "20170102030405") "20170102030405")))
+  (testing "multiple builds in a day"
+    (is (= (#'clj.medusa.alert/build-range "10170102030405" "20170102030405") "10170102030405...20170102030405"))))

--- a/test/medusa/changesets_test.clj
+++ b/test/medusa/changesets_test.clj
@@ -2,13 +2,11 @@
   (:require [clojure.test :refer :all]
             [clj.medusa.changesets :refer [bounding-buildids]]))
 
-(deftest bounding-buildids-single
-  (testing "bounding-buildids when there is only one buildid for the day"
-    (is (= (bounding-buildids "2017-08-02" "mozilla-central") ["20170802100302" "20170802100302"]))))
-
-(deftest bounding-buildids-multiple
-  (testing "bounding-buildids when there are multiple buildids for the day"
+(deftest test-bounding-buildids
+  (testing "when there is only one buildid for the day"
+    (is (= (bounding-buildids "2017-08-02" "mozilla-central") ["20170802100302" "20170802100302"])))
+  (testing "when there are multiple buildids for the day"
     (is (= (bounding-buildids "2017-09-18" "mozilla-central") ["20170918100059" "20170918220054"]))))
 
-(deftest buildid-from-dir
+(deftest test-buildid-from-dir
   (is (= (#'clj.medusa.changesets/buildid-from-dir "2017-09-21-10-01-41-mozilla-central/") "20170921100141")))

--- a/test/medusa/changesets_test.clj
+++ b/test/medusa/changesets_test.clj
@@ -1,7 +1,14 @@
 (ns medusa.changesets-test
   (:require [clojure.test :refer :all]
-            [clj.medusa.changesets :refer [find-date-buildid]]))
+            [clj.medusa.changesets :refer [bounding-buildids]]))
 
-(deftest find-date-buildid-smoke
-  (testing "Unremarkable invocation of find-date-buildid"
-    (is (= (find-date-buildid "2017-09-18" "mozilla-central") "20170918100059"))))
+(deftest bounding-buildids-single
+  (testing "bounding-buildids when there is only one buildid for the day"
+    (is (= (bounding-buildids "2017-08-02" "mozilla-central") ["20170802100302" "20170802100302"]))))
+
+(deftest bounding-buildids-multiple
+  (testing "bounding-buildids when there are multiple buildids for the day"
+    (is (= (bounding-buildids "2017-09-18" "mozilla-central") ["20170918100059" "20170918220054"]))))
+
+(deftest buildid-from-dir
+  (is (= (#'clj.medusa.changesets/buildid-from-dir "2017-09-21-10-01-41-mozilla-central/") "20170921100141")))


### PR DESCRIPTION
Now we always cite a range including the proper changeset in the alert mail, simply by citing the whole day's builds.

Please pay especial attention to `notify-subscribers` when reviewing, as that's where testing peters out.