### PR TITLE
Post directly to Google Groups without going through lists.m.o. Ref #27.

### DIFF
--- a/src/clj/medusa/alert.clj
+++ b/src/clj/medusa/alert.clj
@@ -45,11 +45,11 @@
                          "Evolution dashboard: " evo-url
                          "\n\n"
                          "Changeset for " (build-range earliest-build latest-build) ": " changeset-url)
-                    (concat subscribers foreign_subscribers ["dev-telemetry-alerts@lists.mozilla.org"])))
+                    (concat subscribers foreign_subscribers ["mozilla.dev.telemetry-alerts@googlegroups.com"])))
       (catch Throwable e ; could not find revisions for the given build date
         (log/info e "Retrieving changeset failed")
         (send-email (str "Alert for " metric_name " (" detector_name ") on " date)
                     (str "Alert details: " alert-url)
                          "\n\n"
                          "Evolution dashboard: " evo-url
-                    (concat subscribers foreign_subscribers ["dev-telemetry-alerts@lists.mozilla.org"]))))))
+                    (concat subscribers foreign_subscribers ["mozilla.dev.telemetry-alerts@googlegroups.com"]))))))


### PR DESCRIPTION
We're losing mails somewhere between lists.m.o and Groups, so let's skip a link in the chain and see what happens. This might fix it.